### PR TITLE
add a host_proxy option

### DIFF
--- a/example code/example.php
+++ b/example code/example.php
@@ -116,7 +116,11 @@ try {
 	 * setCalendar()
 	 */
 	
-	$client->connect('http://yourServer/baikal/cal.php/calendars/yourUser/yourCalendar', 'username', 'password');
+    $client->connect('http://yourServer/baikal/cal.php/calendars/yourUser/yourCalendar', 'username', 'password');
+    /* With proxy 
+    $client->connect('http://yourServer/baikal/cal.php/calendars/yourUser/yourCalendar', 'username', 'password', ['proxy_host'=>'http://myproxyip:myproxyport']);
+    */
+
 	
 	$arrayOfCalendars = $client->findCalendars(); // Returns an array of all accessible calendars on the server.
 	

--- a/src/CalDAVClient.php
+++ b/src/CalDAVClient.php
@@ -134,6 +134,11 @@ class CalDAVClient {
                   CURLOPT_SSL_VERIFYPEER => FALSE
                   ));
 
+      // Define Proxy
+      if(isset($options['proxy_host'])) {
+        curl_setopt($this->ch, CURLOPT_PROXY, $options['proxy_host']); 
+      }
+                        
       $this->full_url = $base_url;
       $this->first_url_part = $matches[1];
   }

--- a/src/SimpleCalDAVClient.php
+++ b/src/SimpleCalDAVClient.php
@@ -60,11 +60,11 @@ class SimpleCalDAVClient {
 	 * @throws CalDAVException
 	 * For debugging purposes, just sorround everything with try { ... } catch (Exception $e) { echo $e->__toString(); }
 	 */
-	function connect ( $url, $user, $pass )
+	function connect ( $url, $user, $pass, $options=[] )
 	{
 
 		//  Connect to CalDAV-Server and log in
-		$client = new CalDAVClient($url, $user, $pass);
+		$client = new CalDAVClient($url, $user, $pass, $options);
 
 		// Valid CalDAV-Server? Or is it just a WebDAV-Server?
 		if( ! $client->isValidCalDAVServer() )


### PR DESCRIPTION
add a options array in the connect function
options array by passed to the constructor of CalDAVClient
if options["host_proxy"] is set, the culr option CURLOPT_PROXY is set by this option

it is possible to merge this request for a simple use of curlopt_proxy ?
Thanks